### PR TITLE
replace '.dsk' extension instead of append

### DIFF
--- a/dsk2po.py
+++ b/dsk2po.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # unscramble dsk into po
 # Paul Hagstrom, Dec 2015
-import sys
-import getopt
+import sys, getopt, re
 def main(argv=None):
 	print("dsk2po - convert dsk files to po files")
 
@@ -23,7 +22,7 @@ def main(argv=None):
 		for track in range(35):
 			trackbuffer = dskfile.read(4096)
 			potracks.append(dsk2po(trackbuffer))
-	pofilename = dskfilename + '.po'
+	pofilename = re.sub('\.dsk$', '', dskfilename, flags=re.IGNORECASE) + ".po"
 	print('Writing po image to {}'.format(pofilename))
 	with open(pofilename, mode="wb") as pofile:
 		for potrack in potracks:


### PR DESCRIPTION
The previous behavior always appends `.po` to the output image filename. 

This pull request changes that to conditionally replace `.dsk` with `.po` or add it if the `.dsk` extension doesn't exist.  

Examples with old logic:

- "bob.dsk" -> "bob.dsk.po"
- "bob" -> "bob.po"

Examples with new logic:

- "bob.dsk" -> "bob.po"
- "bob" -> "bob.po"