### PR TITLE
Set the exit code to 0 if conversion is successful

### DIFF
--- a/dsk2po.py
+++ b/dsk2po.py
@@ -27,7 +27,7 @@ def main(argv=None):
 	with open(pofilename, mode="wb") as pofile:
 		for potrack in potracks:
 			pofile.write(potrack)
-	return 1
+	return 0
 
 # From Beneath Apple ProDOS, table 3.1
 # block 000 physical 0, 2 DOS 0, E page 0, 1


### PR DESCRIPTION
I would like to use dsk2po.py in Makefile with a proper exit code value.  Exit code 0 indicates ‘no error’ and the make command continues the process.