### PR TITLE
Update dsk2po.py

### DIFF
--- a/dsk2po.py
+++ b/dsk2po.py
@@ -28,7 +28,7 @@ def main(argv=None):
     for track in range(ntracks):
       trackbuffer = dskfile.read(4096)
       potracks.append(dsk2po(trackbuffer))
-  pofilename = re.sub('\.dsk$', '', dskfilename, flags=re.IGNORECASE) + ".po"
+  pofilename = re.sub(r'\.dsk$', '', dskfilename, flags=re.IGNORECASE) + ".po"
   print('Writing po image to {}'.format(pofilename))
   with open(pofilename, mode="wb") as pofile:
     for potrack in potracks:


### PR DESCRIPTION
Raw String Literals (Recommended): Prefix your string literal with r (e.g., r"your_regex_pattern"). Raw strings treat backslashes literally, preventing Python's string processing from interpreting them as escape sequences. This ensures that the re module receives the pattern exactly as intended